### PR TITLE
add missing variables

### DIFF
--- a/src/utils/terminal.js
+++ b/src/utils/terminal.js
@@ -3,7 +3,36 @@
 
 const tty = require("tty")
 const os = require("os")
+
+// From: https://github.com/sindresorhus/has-flag/blob/main/index.js
+/// function hasFlag(flag, argv = globalThis.Deno?.args ?? process.argv) {
+function hasFlag(flag, argv = globalThis.Deno ? globalThis.Deno.args : process.argv) {
+  const prefix = flag.startsWith('-') ? '' : (flag.length === 1 ? '-' : '--');
+  const position = argv.indexOf(prefix + flag);
+  const terminatorPosition = argv.indexOf('--');
+  return position !== -1 && (terminatorPosition === -1 || position < terminatorPosition);
+}
+
 const { env } = process
+
+let flagForceColor
+
+if (
+  hasFlag('no-color')
+  || hasFlag('no-colors')
+  || hasFlag('color=false')
+  || hasFlag('color=never')
+) {
+  flagForceColor = 0
+} 
+else if (
+  hasFlag('color')
+  || hasFlag('colors')
+  || hasFlag('color=true')
+  || hasFlag('color=always')
+) {
+  flagForceColor = 1
+}
 
 function translateLevel(level) {
   if (level === 0) {


### PR DESCRIPTION
`flagForceColor` and `hasFlag()` were not defined. I've copy-pasted them from the original source

Considering that the comment on top of `src/utils/terminal.js` says  "Lifted _and modified_ from: https://github.com/chalk/supports-color/blob/main/index.js (MIT)", I am not sure there were some modifications in mind related to those variables